### PR TITLE
add replacePath() to replace fullBucketPath in server side

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,21 +101,23 @@ S3Bucket.prototype.handle = function (ctx, next) {
       }
       return filename;
     };
-    var replacePath = function(incomingPath){
-      if(!incomingPath || typeof incomingPath !== 'string'){
-        var cleanName = cleanseFilename(file.name);
-        if(ctx.url.slice(-1)==='/'){
-          fullBucketPath = ctx.url+cleanName;
-        }else{
-          fullBucketPath = ctx.url+'/'+cleanName;
+    var replacePath = function(){
+      var path = '';
+      for(var i in Array.prototype.slice.call(arguments)) {
+        var val = arguments[i];
+        if(typeof val==='string'){
+          if(val.slice(0,1)==='/' && path.slice(-1)==='/'){
+            path += val.slice(1);
+          }else if(val.slice(0,1)==='/' || path.slice(-1)==='/'){
+            path += val;
+          }else{
+            path += '/'+val;
+          }
         }
-      }else{
-        if(ctx.url.slice(-1)==='/'){
-          fullBucketPath = incomingPath;
-        }else{
-          fullBucketPath = '/'+incomingPath;
-        }
-        console.log("replaced bucket path: "+fullBucketPath);
+      }
+      if(path !== ''){
+        console.log("replaced bucket path: "+path);
+        fullBucketPath = path;
       }
       return fullBucketPath;
     };
@@ -128,11 +130,11 @@ S3Bucket.prototype.handle = function (ctx, next) {
         lastFile = file;
         var cleanName = cleanseFilename(file.name);
         console.log('cleanName: '+cleanName);
-        replacePath();
+        replacePath(ctx.url, cleanName);
         if (bucket.events.upload) {
           bucket.events.upload.run(ctx, {url: ctx.url, fileSize: file.size, fileName: cleanName, replacePath: replacePath}, function(err) {
             if (err) return uploadedFile(err);
-            bucket.uploadFile(fullBucketPath, file.size, file.type, fs.createReadStream(file.path), uploadedFile);  
+            bucket.uploadFile(fullBucketPath, file.size, file.type, fs.createReadStream(file.path), uploadedFile);
           });
         } else {
           bucket.uploadFile(fullBucketPath, file.size, file.type, fs.createReadStream(file.path), uploadedFile);

--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ S3Bucket.prototype.handle = function (ctx, next) {
         console.log('cleanName: '+cleanName);
         replacePath(ctx.url, cleanName);
         if (bucket.events.upload) {
-          bucket.events.upload.run(ctx, {url: ctx.url, fileSize: file.size, fileName: cleanName, replacePath: replacePath}, function(err) {
+          bucket.events.upload.run(ctx, {url: ctx.url, fileSize: file.size, fileName: cleanName, basePath: bucket.config.basePath, replacePath: replacePath}, function(err) {
             if (err) return uploadedFile(err);
             bucket.uploadFile(fullBucketPath, file.size, file.type, fs.createReadStream(file.path), uploadedFile);
           });

--- a/package.json
+++ b/package.json
@@ -4,5 +4,8 @@
   "dependencies": {
     "knox": "0.1.x",
     "formidable": "1.0.x"
+  },
+  "devDependencies": {
+    "mocha": "1.20.x"
   }
 }

--- a/test/replacePath.js
+++ b/test/replacePath.js
@@ -1,0 +1,47 @@
+var assert = require("assert");
+
+var fullBucketPath = '/full/bucket/path';
+
+var replacePath = function(){
+  var path = '';
+  for(var i in Array.prototype.slice.call(arguments)) {
+    var val = arguments[i];
+    if(typeof val==='string'){
+      if(val.slice(0,1)==='/' && path.slice(-1)==='/'){
+        path += val.slice(1);
+      }else if(val.slice(0,1)==='/' || path.slice(-1)==='/'){
+        path += val;
+      }else{
+        path += '/'+val;
+      }
+    }
+  }
+  if(path !== ''){
+    console.log("replaced bucket path: "+path);
+    fullBucketPath = path;
+  }
+  return fullBucketPath;
+};
+
+describe('replacePath()', function(){
+  it('should return replaced path and fullBucketPath changed', function(){
+    var expected = '/replace/path';
+    assert.equal(expected, replacePath(expected));
+    assert.equal(expected, fullBucketPath);
+  })
+
+  it('should work with string only', function(){
+    var expected = '/no/change/path';
+    fullBucketPath = expected;
+    assert.equal(expected, replacePath({}));
+    assert.equal(expected, fullBucketPath);
+    assert.equal('/replace/path', replacePath('/replace', {}, '/path'));
+  })
+
+  it('should pass many args', function(){
+    var expected = '/foo/bar/path';
+    assert.equal(expected, replacePath('foo', 'bar', 'path'));
+    assert.equal(expected, replacePath('/foo', 'bar/', '/path'));
+    assert.equal(expected, replacePath('/foo/', 'bar', '/path'));
+  })
+})


### PR DESCRIPTION
I added `replacePath()` method to replace `fullBucketPath`  **on upload** event.
You can use it to generate/sanitize the path to upload.
### Usage

```
// resources/s3bucket/upload.js

// fileName(e.g. 'filename.jpg') is passed from domain.
var path = Math.floor(Math.random()*10); // path = 1;

replacePath(path + '/' + fileName);

// => upload to: https://yourbucket.s3-website-us-east-1.amazonaws.com/1/filename.jpg
```
